### PR TITLE
CI: exclude unsupported Laravel 10 + PHP 8.4 matrix entry

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,7 +13,7 @@ jobs:
     
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2.4.0
+        uses: dependabot/fetch-metadata@v2.5.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,7 +13,7 @@ jobs:
     
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2.3.0
+        uses: dependabot/fetch-metadata@v2.4.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,10 +14,12 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.1, 8.2, 8.3, 8.4]
-        laravel: [10, 11]
+        laravel: [10, 11, '12']
         exclude:
           - php: 8.1
             laravel: 11
+          - laravel: '12'
+            php: 8.1
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 
@@ -37,5 +39,6 @@ jobs:
         run: |
           composer require "illuminate/support=^${{ matrix.laravel }}" --no-update
           composer update --prefer-dist --no-interaction --no-progress
+
       - name: Execute tests
         run: vendor/bin/pest

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.1, 8.2, 8.3, 8.4]
+        php: [8.1, 8.2, 8.3, 8.4, 8.5]
         laravel: [10, 11, '12']
         exclude:
           - php: 8.1

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,6 +20,8 @@ jobs:
             laravel: 11
           - laravel: '12'
             php: 8.1
+          - laravel: 10
+            php: 8.4
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.1, 8.2, 8.3, 8.4, 8.5]
+        php: [8.1, 8.2, 8.3, 8.4]
         laravel: [10, 11, '12']
         exclude:
           - php: 8.1

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: true

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -22,7 +22,7 @@ jobs:
           compare-url-target-revision: ${{ github.event.release.target_commitish }}
 
       - name: Commit updated CHANGELOG
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v6
         with:
           branch: ${{ github.event.release.target_commitish }}
           commit_message: Update CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 4.0.0 - 2025-03-06
+
+### Added
+
+- Laravel 12 Support https://github.com/RahulDey12/laravel-captcha/pull/29
+
 ## 3.0.0 - 2024-03-30
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -19,17 +19,17 @@
     "require": {
         "php": "^8.1",
         "guzzlehttp/guzzle": "^7.5",
-        "illuminate/http": "^10.0|^11.0",
-        "illuminate/support": "^10.0|^11.0",
-        "illuminate/validation": "^10.0|^11.0",
-        "illuminate/view": "^10.0|^11.0"
+        "illuminate/http": "^10.0|^11.0|^12.0",
+        "illuminate/support": "^10.0|^11.0|^12.0",
+        "illuminate/validation": "^10.0|^11.0|^12.0",
+        "illuminate/view": "^10.0|^11.0|^12.0"
     },
     "require-dev": {
         "laravel/pint": "^1.5.0",
         "nunomaduro/collision": "^7.0|^8.0",
-        "orchestra/testbench": "^8.0|^9.0",
-        "pestphp/pest": "^2.0",
-        "rector/rector": "^1.0"
+        "orchestra/testbench": "^8.0|^9.0|^10.0",
+        "pestphp/pest": "^2.0|^3.7",
+        "rector/rector": "^1.0|^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Views/Components/Button.php
+++ b/src/Views/Components/Button.php
@@ -21,7 +21,7 @@ class Button extends Component
 
     public string $nonce;
 
-    public function __construct(public string $formId, string $callback = null)
+    public function __construct(public string $formId, ?string $callback = null)
     {
         $this->site_key = config('captcha.sitekey', '');
         $this->containerClass = Captcha::getContainerClassName();

--- a/src/Views/Components/Container.php
+++ b/src/Views/Components/Container.php
@@ -18,7 +18,7 @@ class Container extends Component
 
     public ?string $size;
 
-    public function __construct(string $theme = null, string $size = null)
+    public function __construct(?string $theme = null, ?string $size = null)
     {
         $this->site_key = config('captcha.sitekey', '');
         $this->theme = $theme ?? config('captcha.theme', 'light');


### PR DESCRIPTION
### Motivation
- Prevent CI failures caused by an unsupported test matrix combination where `laravel: 10` is paired with `php: 8.4`, which can lead to dependency resolution errors during `composer update` in GitHub Actions.

### Description
- Updated the test matrix in `.github/workflows/run-tests.yml` to add an `exclude` entry for `laravel: 10` with `php: 8.4`, removing that unsupported combination from the workflow.

### Testing
- Verified the workflow YAML by loading `.github/workflows/run-tests.yml` (`ruby -e "require 'yaml'; YAML.load_file('.github/workflows/run-tests.yml')"`) which succeeded; ran `php -l` syntax checks across `src`, `tests`, and `config` which reported no syntax errors; `composer install` failed due to network/Packagist access (`CONNECT tunnel failed, response 403`) unrelated to the workflow change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab31e5f3d083248a5b5c2a18a0d9de)